### PR TITLE
Added CLASH_UPDATE, history.

### DIFF
--- a/config/styles/blade-effects.md
+++ b/config/styles/blade-effects.md
@@ -16,6 +16,8 @@ Note that some of these EFFECTS may be included in features used by some prop fi
 The majority of these are self explanitory. 
 Just read EFFECT as "do something during_XXXX"
 
+*Historical tidbit*: Some effects where deprecated for consistency in naming or the introduction of new methods. As such, this documentation is relevant for OS 5.0 and up.
+
 - [General effects](#general-effects)
 - [Blaster effects](#blaster-effects)
 - [Mini game effects](#mini-game-effects)
@@ -26,6 +28,8 @@ Just read EFFECT as "do something during_XXXX"
 ## General effects
 ### EFFECT_NONE
 Never generated, used as defaults in some places to mean "no effect", but is otherwise not useful for anything.
+### CLASH_UPDATE
+*(OS 6.0+)* Internal functions that *shall not* be used on styles.
 
 ### EFFECT_CLASH  
 ### EFFECT_BLAST  
@@ -37,7 +41,9 @@ Never generated, used as defaults in some places to mean "no effect", but is oth
 ### EFFECT_DRAG_BEGIN  
 ### EFFECT_DRAG_END  
 ### EFFECT_PREON  
-### EFFECT_POSTOFF  
+### EFFECT_POSTOFF
+*(OS 6.0+)* 
+
 ### EFFECT_IGNITION  
 ### EFFECT_RETRACTION  
 
@@ -169,8 +175,6 @@ When using a feature that skips preon.
 ### EFFECT_USER3
 ### EFFECT_USER4
 ### EFFECT_USER5
-*(OS 7.0+)* 
-
 ### EFFECT_USER6
 *(OS 7.0+)* 
 

--- a/config/styles/blade-effects.md
+++ b/config/styles/blade-effects.md
@@ -16,8 +16,6 @@ Note that some of these EFFECTS may be included in features used by some prop fi
 The majority of these are self explanitory. 
 Just read EFFECT as "do something during_XXXX"
 
-*Historical tidbit*: Some effects where deprecated for consistency in naming or the introduction of new methods. As such, this documentation is relevant for OS 5.0 and up.
-
 - [General effects](#general-effects)
 - [Blaster effects](#blaster-effects)
 - [Mini game effects](#mini-game-effects)
@@ -29,7 +27,7 @@ Just read EFFECT as "do something during_XXXX"
 ### EFFECT_NONE
 Never generated, used as defaults in some places to mean "no effect", but is otherwise not useful for anything.
 ### CLASH_UPDATE
-*(OS 6.0+)* Internal functions that *shall not* be used on styles.
+*(OS 6.0+)* No effect in blade styles, but may be used in props and other places to detect when the strength of a clash increases after the EFFECT_CLASH has occurred..
 
 ### EFFECT_CLASH  
 ### EFFECT_BLAST  


### PR DESCRIPTION
Added CLASH_UPDATE, gave it and POSTOFF the (6.0+) label, corrected that EFFECT_USER5 was introduced in OS 5.0, so I deleted that label. I did researched which functions where introduced before 5, but since there seems to be a consistency change with old names deprecated, and there's little point to document four versions back, I've just added an historical tidbit clarified that this documentation is relevant to 5.x+ If you wish I could add more labels, but those seems superfluous.